### PR TITLE
Make fade animation speeds configurable

### DIFF
--- a/js/jQuery.BlackAndWhite.js
+++ b/js/jQuery.BlackAndWhite.js
@@ -39,14 +39,17 @@
                     hoverEffect: true,
                     webworkerPath: false,
                     responsive: true,
-                    invertHoverEffect: false
+                    invertHoverEffect: false,
+                    speed: 500
                 };
                 options = $.extend(defaults, options);
             //@public vars
             var hoverEffect = options.hoverEffect,
                 webworkerPath = options.webworkerPath,
                 invertHoverEffect = options.invertHoverEffect,
-                responsive = options.responsive;
+                responsive = options.responsive,
+                fadeSpeedIn = $.isPlainObject(options.speed) ? options.speed.fadeIn : options.speed,
+                fadeSpeedOut = $.isPlainObject(options.speed) ? options.speed.fadeOut : options.speed;
             //@private var
             var supportsCanvas = !!document.createElement('canvas').getContext,
                 $window = $(window);
@@ -122,16 +125,16 @@
                     if (hoverEffect) {
                         $(currImageWrapper).mouseenter(function () {
                             if(!invertHoverEffect) {
-                                $(this).find('canvas').stop(true, true).fadeOut();
+                                $(this).find('canvas').stop(true, true).fadeOut(fadeSpeedOut);
                             } else {
-                                $(this).find('canvas').stop(true, true).fadeIn();
+                                $(this).find('canvas').stop(true, true).fadeIn(fadeSpeedIn);
                             }
                         });
                         $(currImageWrapper).mouseleave(function () {
                             if(!invertHoverEffect) {
-                                $(this).find('canvas').stop(true, true).fadeIn();
+                                $(this).find('canvas').stop(true, true).fadeIn(fadeSpeedIn);
                             } else {
-                                $(this).find('canvas').stop(true, true).fadeOut();
+                                $(this).find('canvas').stop(true, true).fadeOut(fadeSpeedOut);
                             }
                         });
                     }
@@ -153,16 +156,16 @@
                     if (hoverEffect) {
                         $(currImageWrapper).mouseenter(function () {
                             if(!invertHoverEffect) {
-                                $(this).children('.ieFix').stop(true, true).fadeOut();
+                                $(this).children('.ieFix').stop(true, true).fadeOut(fadeSpeedOut);
                             } else {
-                                $(this).children('.ieFix').stop(true, true).fadeIn();
+                                $(this).children('.ieFix').stop(true, true).fadeIn(fadeSpeedIn);
                             }
                         });
                         $(currImageWrapper).mouseleave(function () {
                             if(!invertHoverEffect) {
-                                $(this).children('.ieFix').stop(true, true).fadeIn();
+                                $(this).children('.ieFix').stop(true, true).fadeIn(fadeSpeedIn);
                             } else {
-                                $(this).children('.ieFix').stop(true, true).fadeOut();
+                                $(this).children('.ieFix').stop(true, true).fadeOut(fadeSpeedOut);
                             }
                         });
                     }


### PR DESCRIPTION
I added a new option to the plugin to be able to configure fade animation speeds.

The option 'speed' can either be a single integer value, which will be the speed used in both in and out fade animations, or a plain object having fadeIn and fadeOut properties:

``` javascript
$(".elem").BlackAndWhite({
    speed: 800 // 800ms for both in and out animations
});

$(".elem").BlackAndWhite({
    speed: {
        fadeIn: 200, // 200ms for fadeIn animations
        fadeOut: 800 // 800ms for fadeOut animations
    }
});
```
