### PR TITLE
terminate worker threads after they are finished

### DIFF
--- a/src/BnWWorker.js
+++ b/src/BnWWorker.js
@@ -12,4 +12,16 @@ this.onmessage = function (event) {
 	}  
 	
 	postMessage(imagedata);
+	
+	// terminate the worker
+	
+	// the standard way - http://www.w3.org/TR/workers/#dedicated-workers-and-the-worker-interface
+	if (this.terminate) {
+	    this.terminate();
+	}
+	
+	// IE 10 specific - http://msdn.microsoft.com/en-us/library/ie/hh673568(v=vs.85).aspx
+	if(this.close) {
+	    this.close();
+	}
 }


### PR DESCRIPTION
Each worker thread should be terminated after it finishes processing the image, otherwise the browser keeps it alive and eventually the script hits the maximum concurrent worker limit.
