### PR TITLE
Add img crossOrigin attribute as a parameter in the plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $('.bwWrapper').BlackAndWhite({
     invertHoverEffect: false,
     // this option works only on the modern browsers ( on IE lower than 9 it remains always 1)
     intensity:1,
+    // this option enables/disables the attribute crossorigin=anonymous on image tags. Default true.
+    // please refer to https://github.com/GianlucaGuarini/jQuery.BlackAndWhite#important
+    crossOrigin: true,
     speed: { //this property could also be just speed: value for both fadeIn and fadeOut
         fadeIn: 200, // 200ms for fadeIn animations
         fadeOut: 800 // 800ms for fadeOut animations

--- a/jquery.BlackAndWhite.js
+++ b/jquery.BlackAndWhite.js
@@ -47,7 +47,8 @@
           invertHoverEffect: false,
           speed: 500,
           onImageReady: null,
-          intensity: 1
+          intensity: 1,
+          crossOrigin: true
         }, customOptions),
 
         // options shorthand
@@ -254,7 +255,10 @@
             },
             $overlay;
 
-          img.crossOrigin = 'anonymous';
+          if (options.crossOrigin) {
+            img.crossOrigin = 'anonymous';
+          }
+
 
           if (_supportsCanvas && !_cssfilters) {
             // add the canvas


### PR DESCRIPTION
Hi,
We have a case where the basic authentication is enabled in our server and the `crossorigin=anonymous` attribute prevented the images to load on Microsoft Edge, showing the error:

`HTTP401: DENIED - The requested resource requires user authentication.`

So We implemented and option to enable/disable this attribute.
Thanks!